### PR TITLE
Fix warning about regex

### DIFF
--- a/lib/Config/KingKong/File.pm
+++ b/lib/Config/KingKong/File.pm
@@ -42,7 +42,7 @@ sub new {
 sub process {
    my ($self) = @_;
 
-   my @matches = $self->{target} =~ /\${(\w+)}/g;
+   my @matches = $self->{target} =~ /\$\{(\w+)\}/g;
    $self->{file_vars} = \@matches;
    if ($#matches >= 0) {
       $self->recurse_file(0);


### PR DESCRIPTION
At least with perl 5.22.1 line 45 gives a warning

```
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/\${ <-- HERE (\w+)}/ at /usr/share/perl5/Config/KingKong/File.pm line 45.
```
